### PR TITLE
Update Simplified Chinese translation

### DIFF
--- a/layout/Library/Application Support/YTUHD.bundle/zh_cn.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTUHD.bundle/zh_cn.lproj/Localizable.strings
@@ -1,5 +1,5 @@
 // Settings
 
-"USE_VP9" = "使用VP9编码";
-"USE_VP9_DESC" = "启用最高支持4K分辨率的VP9编解码器。推荐使用搭载A11芯片或以上的机型。更改本设置后需要重启App。";
-"HW_VP9_SUPPORT" = "硬件VP9编码支持状态";
+"USE_VP9" = "使用 VP9 编码";
+"USE_VP9_DESC" = "启用最高支持 4K 分辨率的 VP9 编解码器。推荐使用搭载 A11 芯片或以上的机型（如：iPhone 8/X 或以上）。更改本设置后需要重启 App。";
+"HW_VP9_SUPPORT" = "硬件 VP9 编码支持状态";


### PR DESCRIPTION
Added spaces before and after English letters or numbers per convention and examples for devices "with CPU A11 and higher."